### PR TITLE
fix: Enable trust proxy to fix rate-limiting behind Nginx

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const limiter = rateLimit({
 });
 
 app.use(limiter);
+app.set('trust proxy', 1);
 
 app.get("/", (req, res) => {
   res.send("Hello, World!");


### PR DESCRIPTION
- Enable trust proxy to fix rate-limiting behind Nginx